### PR TITLE
Added recurring attempts to fetch location if received empty location from fused location client

### DIFF
--- a/library/src/main/java/co/subk/zoomsdk/meeting/BaseMeetingActivity.java
+++ b/library/src/main/java/co/subk/zoomsdk/meeting/BaseMeetingActivity.java
@@ -2230,41 +2230,16 @@ public class BaseMeetingActivity extends AppCompatActivity implements ZoomVideoS
         }
 
         if (isLocationEnabled()) {
-            LocationRequest locationRequest = new LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 5000)
-                    .setMinUpdateIntervalMillis(2000)
-                    .setMaxUpdateDelayMillis(5000)
-                    .setMaxUpdates(5)
-                    .build();
-
-            LocationServices.getFusedLocationProviderClient(this).requestLocationUpdates(locationRequest, mLocationCallback, Looper.myLooper());
-
-            new Handler().postDelayed(() -> {
-                LocationEvent bestAccuracyLocationEvent = null;
-                for (LocationEvent locationEvent : locationEvents) {
-                    if (null == bestAccuracyLocationEvent || locationEvent.accuracy < bestAccuracyLocationEvent.accuracy) {
-                        bestAccuracyLocationEvent = locationEvent;
-                    }
-                    Log.i("PUBLISH_LOCATION_EVENT", "Stored locations, latitude : " + locationEvent.latitude + ", longitude : " + locationEvent.longitude + ", accuracy : " + locationEvent.accuracy);
+            locationProviderClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, new CancellationTokenSource().getToken()).addOnSuccessListener(location -> {
+                if (null != location) {
+                    LocationEvent locationEvent = new LocationEvent(location.latitude, location.longitude, location.accuracy, meetingEntityId);
+                    EventBus.getDefault().post(locationEvent);
+                } else {
+                    new Handler().postDelayed(() -> publishLocationEvent(), 5000);
                 }
-                if (bestAccuracyLocationEvent != null) {
-                    Log.i("PUBLISH_LOCATION_EVENT", "So highest accurate location have latitude : " + bestAccuracyLocationEvent.latitude + ", longitude : " + bestAccuracyLocationEvent.longitude + ", accuracy : " + bestAccuracyLocationEvent.accuracy);
-                    EventBus.getDefault().post(bestAccuracyLocationEvent);
-                }
-            }, 30000);
+            });
         }
     }
-
-    private LocationCallback mLocationCallback = new LocationCallback() {
-
-        @Override
-        public void onLocationResult(LocationResult locationResult) {
-            Location mLastLocation = locationResult.getLastLocation();
-            //add this check to make sure last known location should not be null
-            if (mLastLocation != null) {
-                locationEvents.add(new LocationEvent(mLastLocation.getLatitude(), mLastLocation.getLongitude(), mLastLocation.getAccuracy(), meetingEntityId));
-            }
-        }
-    };
 
     public void publishSessionEndedEvent() {
         EventBus.getDefault().post(new SessionEndedEvent(taskId));


### PR DESCRIPTION
Existing logic : Fetching location 5 times every 2 seconds and sending the best out of 5 to backend after 30 seconds (Fused location client method used : [requestLocationUpdates](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient#requestLocationUpdates(com.google.android.gms.location.LocationRequest,%20com.google.android.gms.location.LocationListener,%20android.os.Looper)))
New logic : Fetch location every 5 minutes until we receive it and sync once received (Fused location client method used : [getCurrentLocation](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient#getCurrentLocation(int,%20com.google.android.gms.tasks.CancellationToken)))